### PR TITLE
Search function Error: Failed to fetch, JSON parsing failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ Now, knowing which templates we will be installing, head over to the [/templates
 
 There are a number of ways to install the client depending on your bundler or toolchain. For this guide however, we will be simply adding it as a script tag.
 
-Head over to the [latest release](https://github.com/SatelCreative/crisp/releases) and download `crisp.umd.js`. Next, upload this to your themes `/assets` folder. Now we are ready to import it from the theme.
+Head over to the [latest release](https://github.com/SatelCreative/crisp/releases) and download `crisp.js`. Next, upload this to your themes `/assets` folder. Now we are ready to import it from the theme.
 
 > As with any dependency, it is good practice to only import resources on pages where they are required. For this example however, we will just be adding a global import in `theme.liquid`.
 
-To import Crisp, add `<script type="text/javascript" src="{{ 'crisp.umd.js' | asset_url }}">` in the `<head>` of your `theme.liquid`.
+To import Crisp, add `<script type="text/javascript" src="{{ 'crisp.js' | asset_url }}">` in the `<head>` of your `theme.liquid`.
 
 ### Trying it out
 

--- a/templates/collection.__DO-NOT-SELECT__.products.liquid
+++ b/templates/collection.__DO-NOT-SELECT__.products.liquid
@@ -31,7 +31,7 @@
       TIP: The '| json' filter in liquid is your friend 
     {% endcomment %}
     {
-      "title": {{ product.title | json }},
+      "title": {{ product.title | escape | json }},
       "url": {{ product.url | within: collection | json }},
       "image": {{ product.featured_image.src | product_img_url: 'medium' | json }}
     }

--- a/templates/search.__DO-NOT-SELECT__.liquid
+++ b/templates/search.__DO-NOT-SELECT__.liquid
@@ -34,15 +34,15 @@
     {
       {% if item.object_type == 'article' %}
         "id": {{ item.id | json }},
-        "title": {{ item.title | json }},
+        "title": {{ item.title | escape | json }}
       {% elsif item.object_type == 'page' %}
         "id": {{ item.id | json }},
-        "title": {{ item.title | json }},
+        "title": {{ item.title | escape | json }}
       {% else %}
         "id": {{ item.id | json }},
-        "title": {{ item.title | json }},
+        "title": {{ item.title | escape | json }},
         "url": {{ item.url | json }},
-        "image": {{ item.featured_image.src | json }}
+        "image": {{ item.featured_image.src | json }},
         {% comment %} This is required in products to enable SearchableCollection {% endcomment %}
         "tags": [
           {% for t in product.tags %}


### PR DESCRIPTION
### Overview
Followed the instruction from [README](https://github.com/SatelCreative/crisp#getting-started), Put templates in the template directory, also put crisp.js (v4.5.0) in asset directory.
When I run this code;
​
```
// Create a new instance
var search = Crisp.Search({
  query: 'something keyword', // REQUIRED
  template: '__DO-NOT-SELECT__', // REQUIRED
});
​
// Get the first 10
search.get({
  number: 10,
  callback: function(response) {
    // Handle error
    if (response.error) {
      // Check if due to cancellation
      if (Crisp.isCancel(response.error)) {
        return;
      }
      // Non cancellation error
      throw error;
    }
​
    // Use products
    console.log(response.payload);
  }
});
```
​
I got an error: `Uncaught (in promise) Error: Failed to fetch '/search?view=__DO-NOT-SELECT__': JSON parsing failed`
The issue came from the templates;
- If product, article and page title have apostrophe(s), JSON is invalid
- Article and Page title field have comma, JSON is invalid
- Product image field does not have comma, JSON is invalid
​

I'd like to suggest to implement debug mode because it's really hard to figure them out without debugging.

Thanks!